### PR TITLE
Encode ampersand and fix doctype

### DIFF
--- a/gopher.filter.dpi.c
+++ b/gopher.filter.dpi.c
@@ -132,6 +132,7 @@ static void parse_line(char *line, char *type, char **title, char **selector, ch
 
 static int putchar_htmlenc(char c) {
 	switch (c) {
+		case '&': return printf("&amp;");
 		case '<': return printf("&lt;");
 		case '>': return printf("&gt;");
 		case '"': return printf("&quot;");

--- a/gopher.filter.dpi.c
+++ b/gopher.filter.dpi.c
@@ -378,7 +378,7 @@ static void read_data(int s) {
 
 static void render_dir(int s, const char *url) {
 	dpi_send_header(url, "text/html");
-	printf("<doctype html>");
+	printf("<!DOCTYPE html>");
 	printf("<html><head><title>");
 	print_htmlenc(url);
 	printf("</title></head><body><table>");


### PR DESCRIPTION
Check the author line (here is the [patch](https://patch-diff.githubusercontent.com/raw/dillo-browser/dillo-plugin-gopher/pull/1.patch)), @drawkula

Links with spaces are also not properly handled, as they should be percent-encoded and decoded.

CC @clehner